### PR TITLE
BUGFIX: fix default version of go-patch-cover to use from 0.2.0 to v0.2.0

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -10,7 +10,7 @@ inputs:
     description: |
       The version of go-patch-cover to use.
     required: true
-    default: "0.2.0"
+    default: "v0.2.0"
   coverage_filename:
     description: |
       go coverage file for the code after change.


### PR DESCRIPTION
invalid if using 0.2.0
![image](https://user-images.githubusercontent.com/93907351/197098578-07957a5c-ad74-4df4-829b-716d54ee9c20.png)

but valid if using v0.2.0
![image](https://user-images.githubusercontent.com/93907351/197098465-13e5eebe-a033-4a68-a0cf-bb40deb418fe.png)
